### PR TITLE
Fix quoting in toast script

### DIFF
--- a/show-toast.sh
+++ b/show-toast.sh
@@ -6,6 +6,11 @@ MESSAGE="DONE"
 IMAGE_PATH="$HOME/Documents/Windows Terminal/claude-code.png"
 ATTRIBUTION="From PowerShell"
 
+# Escape single quotes for PowerShell single-quoted strings
+escape_ps() {
+  printf '%s' "$1" | sed "s/'/''/g"
+}
+
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -36,9 +41,14 @@ done
 # Convert WSL path to Windows path
 WIN_IMAGE_PATH=$(wslpath -w "$IMAGE_PATH")
 
+ESC_TITLE=$(escape_ps "$TITLE")
+ESC_MESSAGE=$(escape_ps "$MESSAGE")
+ESC_ATTRIBUTION=$(escape_ps "$ATTRIBUTION")
+ESC_WIN_IMAGE_PATH=$(escape_ps "$WIN_IMAGE_PATH")
+
 # PowerShell command
 powershell.exe -Command "
-  \$img = '$WIN_IMAGE_PATH';
+  \$img = '$ESC_WIN_IMAGE_PATH';
   Import-Module BurntToast;
-  New-BurntToastNotification -Text '$TITLE', '$MESSAGE' -AppLogo \$img -AttributionText '$ATTRIBUTION';
+  New-BurntToastNotification -Text '$ESC_TITLE', '$ESC_MESSAGE' -AppLogo \$img -AttributionText '$ESC_ATTRIBUTION';
 "


### PR DESCRIPTION
## Summary
- ensure show-toast.sh can handle single quotes in input by escaping parameters
- make show-toast.sh executable

## Testing
- `bash -n show-toast.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c09c693188327bae56fff89637d26